### PR TITLE
Don't hardcode the offset

### DIFF
--- a/bootstrap-tooltip-extension.js
+++ b/bootstrap-tooltip-extension.js
@@ -64,7 +64,7 @@
 
         switch (placement) {
         case 'bottom':
-          tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2};
+          tp = {top: pos.top + pos.height - arrowHeight / 2, left: pos.left + pos.width / 2 - actualWidth / 2};
           break;
         case 'top':
           tp = {top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2};
@@ -73,7 +73,7 @@
           tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - arrowWidth};
           break;
         case 'right':
-          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + arrowWidth};
+          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width - arrowWidth / 2};
           break;
         // Extra positions. This are not part of bootstrap
         // Extrange:

--- a/bootstrap-tooltip-extension.js
+++ b/bootstrap-tooltip-extension.js
@@ -18,6 +18,8 @@
     constructor: TooltipExtension
   , show: function () {
       var $tip
+        , $arrow
+        , arrowHeight
         , pos
         , actualWidth
         , actualHeight
@@ -55,6 +57,9 @@
         actualWidth = $tip[0].offsetWidth;
         actualHeight = $tip[0].offsetHeight;
 
+        $arrow = this.$tip.find(".tooltip-arrow, .arrow");
+        arrowHeight = (parseInt($arrow.css('borderTopWidth')) + parseInt($arrow.css('borderBottomWidth')));
+
         switch (placement) {
         case 'bottom':
           tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2};
@@ -74,25 +79,25 @@
         //  And 10px bigger in 'bottom-left' and 'bottom-right'
         // This should behave like 'top' and 'bottom'. But they don't.
         case 'bottom-left':
-          tp = {top: pos.top + pos.height + 10, left: pos.left};
+          tp = {top: pos.top + pos.height + arrowHeight, left: pos.left};
           if (this.$element.outerWidth() <= 18) { // if button is small move tooltip left
             tp.left -= 4;
           }
           break;
         case 'bottom-right':
-          tp = {top: pos.top + pos.height + 10, left: pos.left + pos.width - actualWidth};
+          tp = {top: pos.top + pos.height + arrowHeight, left: pos.left + pos.width - actualWidth};
           if (this.$element.outerWidth() <= 18) { // if button is small move tooltip left
             tp.left += 4;
           }
           break;
         case 'top-left':
-          tp = {top: pos.top - actualHeight - 10, left: pos.left };
+          tp = {top: pos.top - actualHeight - arrowHeight, left: pos.left };
           if (this.$element.outerWidth() <= 18) { // if button is small move tooltip left
             tp.left -= 4;
           }
           break;
         case 'top-right':
-          tp = {top: pos.top - actualHeight - 10, left: pos.left + pos.width - actualWidth};
+          tp = {top: pos.top - actualHeight - arrowHeight, left: pos.left + pos.width - actualWidth};
           if (this.$element.outerWidth() <= 18) { // if button is small move tooltip left
             tp.left += 4;
           }

--- a/bootstrap-tooltip-extension.js
+++ b/bootstrap-tooltip-extension.js
@@ -19,6 +19,7 @@
   , show: function () {
       var $tip
         , $arrow
+        , arrowWidth
         , arrowHeight
         , pos
         , actualWidth
@@ -58,6 +59,7 @@
         actualHeight = $tip[0].offsetHeight;
 
         $arrow = this.$tip.find(".tooltip-arrow, .arrow");
+        arrowWidth = (parseInt($arrow.css('borderLeftWidth')) + parseInt($arrow.css('borderRightWidth')));
         arrowHeight = (parseInt($arrow.css('borderTopWidth')) + parseInt($arrow.css('borderBottomWidth')));
 
         switch (placement) {
@@ -68,10 +70,10 @@
           tp = {top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2};
           break;
         case 'left':
-          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth};
+          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth - arrowWidth};
           break;
         case 'right':
-          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width};
+          tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width + arrowWidth};
           break;
         // Extra positions. This are not part of bootstrap
         // Extrange:


### PR DESCRIPTION
The tooltip appears way to much above/below the related element. This is due to the hardcoded offset of 10px. Rather than hardcoding it, get it programmatically via $.css(). This PR adds two more variables to get hands on the arrow and its height and replaces the hardcoded offset by the calculated one. This also allows designers to override the offset (border-width) through css.
